### PR TITLE
Upgrade to srs 0.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "main": "index.js",
     "keywords": ["mapbox", "mapnik"],
     "dependencies": {
-        "srs": "0.3.12",
+        "srs": "~0.4.1",
         "mapnik": "~1.4.4",
         "sphericalmercator": "1.0.2"
     },


### PR DESCRIPTION
Updates node srs so users of mapnik-omnivore can benefit from pre-built srs binaries.
