### PR TITLE
Bumped gdal to 0.1.2.

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "srs": "~0.4.3",
     "mapnik": "~1.4.10",
     "sphericalmercator": "1.0.2",
-    "gdal": "0.1.1"
+    "gdal": "0.1.2"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This fixes a bug that could cause projection info to be occasionally incorrect (had to do with caching).
