### PR TITLE
Reduce scope of try/catch blocks

### DIFF
--- a/lib/datasourceProcessor.js
+++ b/lib/datasourceProcessor.js
@@ -307,23 +307,23 @@ function processRasterDatasource(file, filesize, name, info, filetype, callback)
         var ds = new mapnik.Datasource(options);
         var ref = gdal.SpatialReference.fromProj4(info.proj4);
         var results = getCenterAndExtent(ds, info.proj4, filetype);
-        //calculate source's min/max zoom
-        getMinMaxZoomGDAL(info.raster.pixelSize, results.center, info.proj4, function(err, min, max) {
-            if (err) return callback(err);
-            //Values to input into xml for Mapnik
-            return callback(null, {
-                extent: results.extent,
-                center: results.center,
-                raster: info.raster,
-                proj: info.proj4,
-                minzoom: min,
-                maxzoom: max,
-                dstype: 'gdal'
-            });
-        });
     } catch(err){
         return callback(invalid(err));
     }
+    //calculate source's min/max zoom
+    getMinMaxZoomGDAL(info.raster.pixelSize, results.center, info.proj4, function(err, min, max) {
+        if (err) return callback(err);
+        //Values to input into xml for Mapnik
+        return callback(null, {
+            extent: results.extent,
+            center: results.center,
+            raster: info.raster,
+            proj: info.proj4,
+            minzoom: min,
+            maxzoom: max,
+            dstype: 'gdal'
+        });
+    });
 };
 /**
  * Calculates a GDAL source's min and max zoom level using native pixel size and converting to google mercator (meters)
@@ -419,10 +419,10 @@ function projectionFromRaster(file, callback) {
         
         //get bands and bandStats
         bands = getBands(ds, bandCount);
-        if(bands instanceof Error) return callback(bands);
     } catch(err) {
         return callback(invalid('Invalid gdal source. ' + err));
     }   
+    if (bands instanceof Error) return callback(bands);
 
     //TODO: check if the current projection is something we can deal with
     //...what are some projections we can't deal with?
@@ -615,10 +615,10 @@ function getDatasource(options, layers, callback) {
     if (options.layer_by_index === 0) {
         try {
             var ds = new mapnik.Datasource(options);
-            return callback(null, ds);
         } catch (err) {
             return callback(invalid('Error creating Mapnik Datasource for .geojson file'));
         }
+        return callback(null, ds);
         //else obtain layers from KML or gpx file
     } else {
         var validDatasource;


### PR DESCRIPTION
Moves code that doesn't need catching out of `try/catch` blocks. In particular calling a passed callback within a `try` block can have unintended consequences:

```
// callback someone else passes to our API.
// it has a bad call to undefinedFunction(), leading to an exception.
function done(err, data) {
    if (err) return console.warn(err);
    undefinedFunction();
}

function mymodule(options, callback) {
    try {
        // this code is good and will not throw
        var data = 5 + 5;
        // but the callback itself may throw, and isn't our code!
        callback(null, data);
    } catch(err) {
        callback(new Error('error occurred!'));
    }
}

> mymodule({}, done);
[Error: error occurred!]
```

The gist: if callback is wrapped by `try` you'll potentially end up catching other people's errors too and masking them making it look like an error occurred in `mapnik-omnivore` when it's really in the API caller's code.
