### PR TITLE
Roundup maxzoom

### DIFF
--- a/lib/datasource-processor.js
+++ b/lib/datasource-processor.js
@@ -358,7 +358,7 @@ function getMinMaxZoomGDAL(pixelSize, center, proj, callback) {
       return res > pixelSize[0]
     });
     
-    var maxzoom = validSpatialResolutions.length - 1;
+    var maxzoom = validSpatialResolutions.length;
     var minzoom = Math.max(0, maxzoom - 6);
     
     return callback(null, minzoom, maxzoom);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mapnik-omnivore",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "description": "Node module that returns metadata of spatial files.",
   "main": "index.js",
   "keywords": [

--- a/test/datasource-processor.test.js
+++ b/test/datasource-processor.test.js
@@ -487,8 +487,8 @@ var UPDATE = process.env.UPDATE;
         });
     });
     tape('Setting min/max zoom for GDAL sources: should return expected values for min/maxzoom', function(assert) {
-        var expectedMin = 8;
-        var expectedMax = 14;
+        var expectedMin = 9;
+        var expectedMax = 15;
         var proj = "+proj=aea +lat_1=29.5 +lat_2=45.5 +lat_0=23 +lon_0=-96 +x_0=0 +y_0=0 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs";
         var center = [-110.32476292309875,44.56502238336985];
         var pixelSize = [ 7.502071930146189, 7.502071930145942 ];
@@ -502,8 +502,8 @@ var UPDATE = process.env.UPDATE;
     
     tape('Setting min/max zoom for Landsat 8 source: should not exceed z12', function(assert) {
       
-      var expectedMin = 6;
-      var expectedMax = 12;
+      var expectedMin = 7;
+      var expectedMax = 13;
       
       var proj = "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext  +no_defs";
       

--- a/test/fixtures/metadata_sample_tif.json
+++ b/test/fixtures/metadata_sample_tif.json
@@ -12,8 +12,8 @@
         "stats": {
           "min": 0,
           "max": 100,
-          "mean": 29.725628716175,
-          "std_dev": 36.988859543635
+          "mean": 29.725628716175223,
+          "std_dev": 36.98885954363488
         },
         "scale": 1,
         "unitType": "",
@@ -59,8 +59,8 @@
     -110.28443250326441,
     44.596766518228264
   ],
-  "minzoom": 8,
-  "maxzoom": 14,
+  "minzoom": 9,
+  "maxzoom": 15,
   "dstype": "gdal",
   "filetype": ".tif",
   "layers": [

--- a/test/fixtures/metadata_sample_vrt.json
+++ b/test/fixtures/metadata_sample_vrt.json
@@ -59,8 +59,8 @@
     -110.28443250326441,
     44.596766518228264
   ],
-  "minzoom": 8,
-  "maxzoom": 14,
+  "minzoom": 9,
+  "maxzoom": 15,
   "dstype": "gdal",
   "filetype": ".vrt",
   "layers": [


### PR DESCRIPTION
Per discussion with @yhahn and @rclark, this is to avoid losing data by rounding down a zoom level. 

Instead of affecting all users with a change needed for our team's purpose, keep zoom levels the same for users and find a better solution to our user-case(s) going forward. At least for now, this will mean swallowing the costs of tiling/storing higher zoom levels we don't need for the satellite base layer. But this will hopefully push us to come up with longterm solutions to the problems we are running into for raster mosaics.

cc @kapadia @camillacaros 

 