### PR TITLE
Adjust reading projection from rasters

### DIFF
--- a/lib/datasource-processor.js
+++ b/lib/datasource-processor.js
@@ -1,6 +1,7 @@
 var fs = require('fs'),
     path = require('path'),
-    sphericalMerc = new(require('sphericalmercator')),
+    SphericalMercator = require('sphericalmercator'),
+    sphericalMerc = new SphericalMercator(),
     invalid = require('./invalid'),
     srs = require('srs'),
     gdal = require('gdal'),
@@ -21,7 +22,7 @@ function init(file, filesize, filetype, callback) {
         if (err) return callback(err);
         return callback(null, configs);
     });
-};
+}
 /**
  * Obtains metadata depending on file type
  * @param file (filepath)
@@ -34,7 +35,7 @@ function getDatasourceConfigs(file, filesize, filetype, callback) {
         if(err) return callback(err);
         var name = path.basename(file, path.extname(file));
         if(filetype === '.geojson') name = name.replace('.geo', '');
-                
+
         if(filetype === '.tif' || filetype === '.vrt') {
             processRasterDatasource(file, filesize, name, proj, filetype, function(err, info) {
                 if(err) return callback(err);
@@ -51,7 +52,7 @@ function getDatasourceConfigs(file, filesize, filetype, callback) {
                     filetype: filetype,
                     layers: [name]
                 });
-            }); 
+            });
         // shapefile datasource
         } else if (filetype === '.shp' || filetype === '.csv') {
             processDatasource(file, filesize, name, proj, filetype, function(err, info) {
@@ -90,7 +91,7 @@ function getDatasourceConfigs(file, filesize, filetype, callback) {
             });
         }
     });
-};
+}
 /**
  * Obtains projection based on filetype
  * @param file (filepath)
@@ -115,7 +116,7 @@ function getProjection(file, filetype, callback) {
     //else kml and gpx
     }
     else return callback(null, '+init=epsg:4326');
-};
+}
 /**
  * Obtains extent from the datasource and the center point (lat/lng)
  * @param ds (Mapnik datasource)
@@ -128,7 +129,7 @@ function getCenterAndExtent(ds, projection) {
     // Convert datasource extent to lon/lat when saving
     var fromProj = new mapnik.Projection(projection);
     var toProj = new mapnik.Projection('+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs');
-        
+
     if (fromProj === toProj) {
         try {
             extent = ds.extent();
@@ -144,15 +145,15 @@ function getCenterAndExtent(ds, projection) {
             return invalid('Error obtaining extent of Mapnik datasource.');
         }
     }
-    
+
     //Center point of bounding box (extent)
     var center = [0.5 * (extent[0] + extent[2]), 0.5 * (extent[1] + extent[3])];
     var results = {
         extent: extent,
         center: center
-    }
+    };
     return results;
-};
+}
 /**
  * Gets min/max zoom levels based on filesize
  * @param bytes (size of file)
@@ -196,8 +197,8 @@ function getMinMaxZoom(bytes, extent, callback) {
             minzoom = 0;
             return callback(null, minzoom, maxzoom);
         }
-    };
-};
+    }
+}
 /**********************
  * Shape and CSV files
  **********************/
@@ -260,7 +261,7 @@ function processDatasource(file, filesize, name, proj, filetype, callback) {
             dstype: dstype
         });
     });
-};
+}
  /**
  * Obtains projection from a shapefile by reading the .prj file in the same directory
  * @param file (filepath)
@@ -271,11 +272,11 @@ function projectionFromShape(file, callback) {
     //Assumes the .prj file has the same name as the .shp file
     var projFile = fileDir + "/" + (path.basename(file, path.extname(file))) + '.prj';
     fs.readFile(projFile, function(err, data) {
-        if(err) return callback(invalid('Missing projection file.'));
+        if (err) return callback(invalid('Missing projection file.'));
+
         var result;
-        try {
-            result = srs.parse(data);
-        } catch (err) {
+        try { result = srs.parse(data); }
+        catch(error) {
             return callback(invalid('Invalid projection file.'));
         }
         //TODO: check if the current projection is something we can deal with
@@ -283,9 +284,8 @@ function projectionFromShape(file, callback) {
         //Currently handles issues with ESRI projections
         if (result.proj4 === undefined) {
             // Prepend ESRI:: and try parse again.
-            try {
-                result = srs.parse('ESRI::' + data.toString());
-            } catch (err) {
+            try { result = srs.parse('ESRI::' + data.toString()); }
+            catch(error) {
                 return callback(invalid('Still...Invalid projection file.'));
             }
             // handle undefined proj4 string case
@@ -296,7 +296,7 @@ function projectionFromShape(file, callback) {
             return callback(null, result.proj4);
         }
     });
-};
+}
 
 
 /********************
@@ -313,13 +313,14 @@ function projectionFromShape(file, callback) {
 */
 function processRasterDatasource(file, filesize, name, info, filetype, callback) {
     var options = {
-        type: 'gdal', 
+        type: 'gdal',
         file: file
     };
+    var results;
     try{
         var ds = new mapnik.Datasource(options);
         var ref = gdal.SpatialReference.fromProj4(info.proj4);
-        var results = getCenterAndExtent(ds, info.proj4, filetype);
+        results = getCenterAndExtent(ds, info.proj4, filetype);
     } catch(err){
         return callback(invalid(err));
     }
@@ -337,7 +338,7 @@ function processRasterDatasource(file, filesize, name, info, filetype, callback)
             dstype: 'gdal'
         });
     });
-};
+}
 /**
  * Calculates a GDAL source's min and max zoom level using native pixel size and converting to google mercator (meters)
  * @param pixelSize (source's pixel size Array)
@@ -347,26 +348,26 @@ function processRasterDatasource(file, filesize, name, info, filetype, callback)
  */
 function getMinMaxZoomGDAL(pixelSize, center, proj, callback) {
     var circumference = 40075000;
-    
+
     // Create lookup table to determine max zoom level for given spatial resolution
     var zoomLevels = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19];
     var spatialResolutions = zoomLevels.map(function(z) {
         return circumference * Math.cos(0) / Math.pow(2, (z + 8));
     });
-    
+
     var validSpatialResolutions = spatialResolutions.filter(function(res) {
-      return res > pixelSize[0]
+      return res > pixelSize[0];
     });
-    
+
     var maxzoom = validSpatialResolutions.length;
     var minzoom = Math.max(0, maxzoom - 6);
-    
+
     return callback(null, minzoom, maxzoom);
 }
 /**
  * Detects unit type of the gdal source, using the srs/projection
  * @param srs
- * @returns unit type (String) 
+ * @returns unit type (String)
  */
 function getUnitType(srs){
     var possibleUnits = ['m','ft','mi','km','us-ft','us-mi'];
@@ -376,72 +377,65 @@ function getUnitType(srs){
     if(srs.indexOf("+units=") === -1 && srs.indexOf("+proj=longlat") !== -1) return 'decimal degrees';
     //Default to meters for now, if nothing matches
     else return 'm';
-};
+}
+
 /**
  * Obtains projection from a raster by using node-gdal lib
  * @param file (filepath)
  * @returns result.proj4 and raster properties object
  */
-function projectionFromRaster(file, callback) {
+function projectionFromRaster(filepath, callback) {
+    var info = { raster: {} };
+
     var ds;
-    var proj;
-    var band;
-    var bandCount;
-    var bandStats;
-    var width;
-    var height;
-    var geotransform;
-    var bands;
-    var nodata;
-    var unitType;
-    var metadata;
-    var fileList;
-    var srsResult;
-    
+    try { ds = gdal.open(filepath); }
+    catch(err) {
+        return callback(invalid('Invalid GeoTIFF: could not open the file'));
+    }
+
     try {
-        ds = gdal.open(file);
-        geotransform = ds.geoTransform;
-        bandCount = ds.bands.count();
-        width = ds.rasterSize.x;
-        height = ds.rasterSize.y;
-        proj = ds.srs.toWKT();
-        fileList = ds.getFileList();
-        //get srs string
-        srsResult = srs.parse(proj);
+        info.raster.width = ds.rasterSize.x;
+        info.raster.height = ds.rasterSize.y;
+    }
+    catch(err) {
+        return callback(invalid('Invalid GeoTIFF: could not read image dimensions'));
+    }
 
-        //get native units/pixel
-        var ref = gdal.SpatialReference.fromProj4(srsResult.proj4);
-        var linearUnits = ref.getLinearUnits();
-        var angularUnits = ref.getAngularUnits();
-        
-        //get bands and bandStats
-        bands = getBands(ds, bandCount);
-    } catch(err) {
-        return callback(invalid('Invalid gdal source. ' + err.message));
-    }   
-    if (bands instanceof Error) return callback(bands);
+    try {
+        info.raster.bandCount = ds.bands.count();
+        info.raster.bands = getBands(ds, ds.bands.count());
+        info.raster.nodata = info.raster.bands[0].nodata;
+    }
+    catch(err) {
+        if (err.code == 'EINVALID') return callback(err);
+        return callback(invalid('Invalid GeoTIFF: could not get band information'));
+    }
 
-    //TODO: check if the current projection is something we can deal with
-    //...what are some projections we can't deal with?
-    if(srsResult.proj4 === undefined){
-        return callback(invalid('Undefined projection from gdal source.'));
-    } else return callback(null, {
-        'proj4': srsResult.proj4,
-        'raster':{
-            'pixelSize': [geotransform[1],-geotransform[5]], 
-            'bandCount': bandCount,
-            'bands': bands,
-            'nodata': bands[0].nodata,
-            'origin': [geotransform[0], geotransform[3]],
-            'width': width,
-            'height': height,
-            'units':{
-                'linear': linearUnits,
-                'angular': angularUnits
-            }
-        }
-    });
-};
+    try {
+        // TODO: check if the current projection is something we can deal with
+        // ...what are some projections we can't deal with?
+        info.proj4 = srs.parse(ds.srs.toWKT()).proj4;
+        var ref = gdal.SpatialReference.fromProj4(info.proj4);
+        info.raster.units = {
+            linear: ref.getLinearUnits(),
+            angular: ref.getAngularUnits()
+        };
+    }
+    catch(err) {
+        return callback(invalid('Invalid GeoTIFF: could not read spatial reference information'));
+    }
+
+    try {
+        var geotransform = ds.geoTransform;
+        info.raster.pixelSize = [ geotransform[1], -geotransform[5] ];
+        info.raster.origin = [ geotransform[0], geotransform[3] ];
+    }
+    catch(err) {
+        return callback(invalid('Invalid GeoTIFF: could not read georeferencing information'));
+    }
+
+    callback(null, info);
+}
 /**
  * Iterates through source's bands and obtains band properties
  * @param ds (Datasource)
@@ -459,15 +453,15 @@ function getBands(ds, bandCount){
         nodata = band.noDataValue;
         unitType = ds.bands.get(i).unitType;
         //Error check file sources
-        try { 
+        try {
             bandStats = band.getStatistics(false, true);
         } catch(err){
-            return invalid("Error getting statistics of band. 1 or more of the VRT file's relative sources may be missing: " + err.message);
-        };
+            throw invalid("Error getting statistics of band. 1 or more of the VRT file's relative sources may be missing: " + err.message);
+        }
         //add to bands array
         bands.push({
             //commenting out band for now, seems to be erroring out when trying to stringify C++ object
-            //'band':band, 
+            //'band':band,
             'stats':bandStats,
             'scale':band.scale,
             'unitType':unitType,
@@ -480,9 +474,9 @@ function getBands(ds, bandCount){
             'blockSize':band.blockSize,
             'color':band.colorInterpretation
         });
-    };
+    }
     return bands;
-};
+}
 
 /************
  * OGR files
@@ -503,7 +497,7 @@ function processOgrDatasource(file, filesize, proj, filetype, callback) {
         //if error returned from synchronous function, send Error to callback
         if (results instanceof Error) {
             return callback(results);
-        };
+        }
         getMinMaxZoom(filesize, results.extent, function(err, min, max) {
             if (err) return callback(err);
             //object to hold layer attributes
@@ -531,24 +525,25 @@ function processOgrDatasource(file, filesize, proj, filetype, callback) {
             });
         });
     });
-};
+}
  /**
  * Creates a mapnik Datasource and uses that to obtain the file's spatial properties
  * @param file (filepath)
  * @param name
  * @param filetype
- * @returns layers (file's layer names) 
- *          json (vector_layers array) 
+ * @returns layers (file's layer names)
+ *          json (vector_layers array)
  *          ds (mapnik Datasource)
  */
 function getDatasourceProperties(file, filetype, callback) {
     var dstype = 'ogr';
+    var options = {};
+
     //Get layers for kml or geojson/topojson
     if (filetype === '.kml' || filetype === '.geojson') {
-        var options = {
-            type: dstype,
-            file: file
-        };
+        options.type = dstype;
+        options.file = file;
+
         //Get KML/geojson layer names from the OGR error message...for now
         getLayers(options, function(err, layers) {
             if (err) return callback(err);
@@ -557,12 +552,12 @@ function getDatasourceProperties(file, filetype, callback) {
                 else return callback(null, layers, ds);
             });
         });
+
         //Get layers for .gpx
     } else if (filetype === '.gpx') {
-        var options = {
-            type: dstype,
-            file: file
-        };
+        options.type = dstype;
+        options.file = file;
+
         //GPX files can only have these layers
         var layers = ['waypoints', 'routes', 'tracks', 'route_points', 'track_points'];
         getDatasource(options, layers, function(err, ds) {
@@ -570,7 +565,7 @@ function getDatasourceProperties(file, filetype, callback) {
             return callback(null, layers, ds);
         });
     }
-};
+}
 
 //Sole purpose is to obtain layer names from OGR error message
 function getLayers(options, callback) {
@@ -592,7 +587,7 @@ function getLayers(options, callback) {
     }
     if (error === undefined) return callback(null, layers_array);
     else return callback(invalid('Error obtaining layer names'));
-};
+}
 
 //Create a datasource, which is later used to obtain extent and center of the source
 function getDatasource(options, layers, callback) {
@@ -620,7 +615,7 @@ function getDatasource(options, layers, callback) {
     if (error === undefined && validDatasource !== undefined) return callback(null, validDatasource);
     else if (validDatasource === undefined) return callback(invalid('Source appears to have no features data.'));
     else return callback(error);
-};
+}
 module.exports = {
     init: init,
     getCenterAndExtent: getCenterAndExtent,

--- a/test/datasource-processor.test.js
+++ b/test/datasource-processor.test.js
@@ -10,9 +10,9 @@ var expectedMetadata_world_merc = JSON.parse(fs.readFileSync(path.resolve('test/
 var expectedMetadata_fells_loop = JSON.parse(fs.readFileSync(path.resolve('test/fixtures/metadata_fells_loop.json')));
 var expectedMetadata_DC_polygon = JSON.parse(fs.readFileSync(path.resolve('test/fixtures/metadata_DC_polygon.json')));
 var expectedMetadata_bbl_csv = JSON.parse(fs.readFileSync(path.resolve('test/fixtures/metadata_bbl_current_csv.json')));
-var expectedMetadata_1week_earthquake = JSON.parse(fs.readFileSync(path.resolve('test/fixtures/metadata_1week_earthquake.json')));   
+var expectedMetadata_1week_earthquake = JSON.parse(fs.readFileSync(path.resolve('test/fixtures/metadata_1week_earthquake.json')));
 var expectedMetadata_sample_tif = JSON.parse(fs.readFileSync(path.resolve('test/fixtures/metadata_sample_tif.json')));
-var expectedMetadata_sample_vrt = JSON.parse(fs.readFileSync(path.resolve('test/fixtures/metadata_sample_vrt.json')));     
+var expectedMetadata_sample_vrt = JSON.parse(fs.readFileSync(path.resolve('test/fixtures/metadata_sample_vrt.json')));
 var expectedMetadata_topo = JSON.parse(fs.readFileSync(path.resolve('test/fixtures/metadata_topo.json')));
 
 var UPDATE = process.env.UPDATE;
@@ -207,10 +207,13 @@ var UPDATE = process.env.UPDATE;
         var type = '.shp';
         //Overwrites metadata json file if output does not match
         datasourceProcessor.init(shpFile, filesize, type, function(err, metadata) {
-            if (err) return done(err);
+            if (err) {
+                assert.ifError(err, 'should not error');
+                return assert.end();
+            }
             if (UPDATE) fs.writeFileSync(path.resolve('test/fixtures/metadata_world_merc.json'), JSON.stringify(metadata, null, 2));
             assert.deepEqual(metadata, expectedMetadata_world_merc);
-            
+
             assert.end();
         });
     });
@@ -220,7 +223,10 @@ var UPDATE = process.env.UPDATE;
         var filesize = 428328;
         var type = '.shp';
         datasourceProcessor.init(shpFile, filesize, type, function(err, metadata) {
-            if (err) return done(err);
+            if (err) {
+                assert.ifError(err, 'should not error');
+                return assert.end();
+            }
             assert.ok(err === null);
             assert.deepEqual(metadata, expectedMetadata_world_merc);
             assert.end();
@@ -232,7 +238,10 @@ var UPDATE = process.env.UPDATE;
         var type = '.tif';
         //Overwrites metadata json file if output does not match
         datasourceProcessor.init(tifFile, filesize, type, function(err, metadata) {
-            if (err) return done(err);
+            if (err) {
+                assert.ifError(err, 'should not error');
+                return assert.end();
+            }
             if (UPDATE) fs.writeFileSync(path.resolve('test/fixtures/metadata_sample_tif.json'), JSON.stringify(metadata, null, 2));
             if (UPDATE) assert.deepEqual(metadata, expectedMetadata_sample_tif);
             assert.end();
@@ -245,10 +254,13 @@ var UPDATE = process.env.UPDATE;
         var type = '.tif';
         var trunc_6 = function(val) {
             return Number(val.toFixed(6));
-        }
+        };
 
         datasourceProcessor.init(tifFile, filesize, type, function(err, metadata) {
-            if (err) return done(err);
+            if (err) {
+                assert.ifError(err, 'should not error');
+                return assert.end();
+            }
 
             //Round extent values to avoid floating point discrepancies in Travis
             metadata.center[0] = trunc_6(metadata.center[0]);
@@ -286,7 +298,10 @@ var UPDATE = process.env.UPDATE;
         var type = '.vrt';
         //Overwrites metadata json file if output does not match
         datasourceProcessor.init(vrtFile, filesize, type, function(err, metadata) {
-            if (err) return done(err);
+            if (err) {
+                assert.ifError(err, 'should not error');
+                return assert.end();
+            }
             if (UPDATE) fs.writeFileSync(path.resolve('test/fixtures/metadata_sample_vrt.json'), JSON.stringify(metadata, null, 2));
             if (UPDATE) assert.deepEqual(metadata, expectedMetadata_sample_vrt);
             assert.end();
@@ -302,7 +317,10 @@ var UPDATE = process.env.UPDATE;
         }
 
         datasourceProcessor.init(vrtFile, filesize, type, function(err, metadata) {
-            if (err) return done(err);
+            if (err) {
+                assert.ifError(err, 'should not error');
+                return assert.end();
+            }
 
             //Round extent values to avoid floating point discrepancies in Travis
             metadata.center[0] = trunc_6(metadata.center[0]);
@@ -341,7 +359,10 @@ var UPDATE = process.env.UPDATE;
         var type = '.csv';
         //Overwrites metadata json file if output does not match
         datasourceProcessor.init(csvFile, filesize, type, function(err, metadata) {
-            if (err) return done(err);
+            if (err) {
+                assert.ifError(err, 'should not error');
+                return assert.end();
+            }
             if (UPDATE) fs.writeFileSync(path.resolve('test/fixtures/metadata_bbl_current_csv.json'), JSON.stringify(metadata, null, 2));
             assert.deepEqual(metadata, expectedMetadata_bbl_csv);
 
@@ -354,7 +375,10 @@ var UPDATE = process.env.UPDATE;
         var filesize = 1667;
         var type = '.csv';
         datasourceProcessor.init(csvFile, filesize, type, function(err, metadata) {
-            if (err) return done(err);
+            if (err) {
+                assert.ifError(err, 'should not error');
+                return assert.end();
+            }
             assert.ok(err === null);
             assert.deepEqual(metadata, expectedMetadata_bbl_csv);
             assert.end();
@@ -366,7 +390,10 @@ var UPDATE = process.env.UPDATE;
         var type = '.kml';
         //Overwrites metadata json file if output does not match
         datasourceProcessor.init(kmlFile, filesize, type, function(err, metadata) {
-            if (err) return done(err);
+            if (err) {
+                assert.ifError(err, 'should not error');
+                return assert.end();
+            }
             if (UPDATE) fs.writeFileSync(path.resolve('test/fixtures/metadata_1week_earthquake.json'), JSON.stringify(metadata, null, 2));
             assert.deepEqual(metadata, expectedMetadata_1week_earthquake);
 
@@ -379,7 +406,10 @@ var UPDATE = process.env.UPDATE;
         var filesize = 1082451;
         var type = '.kml';
         datasourceProcessor.init(kmlFile, filesize, type, function(err, metadata) {
-            if (err) return done(err);
+            if (err) {
+                assert.ifError(err, 'should not error');
+                return assert.end();
+            }
             assert.ok(err === null);
             assert.deepEqual(metadata, expectedMetadata_1week_earthquake);
             assert.end();
@@ -391,7 +421,10 @@ var UPDATE = process.env.UPDATE;
         var type = '.geojson';
         //Overwrites metadata json file if output does not match
         datasourceProcessor.init(geoJsonFile, filesize, type, function(err, metadata) {
-            if (err) return done(err);
+            if (err) {
+                assert.ifError(err, 'should not error');
+                return assert.end();
+            }
             if (UPDATE) fs.writeFileSync(path.resolve('test/fixtures/metadata_DC_polygon.json'), JSON.stringify(metadata, null, 2));
             assert.deepEqual(metadata, expectedMetadata_DC_polygon);
 
@@ -404,7 +437,10 @@ var UPDATE = process.env.UPDATE;
         var filesize = 367;
         var type = '.geojson';
         datasourceProcessor.init(geoJsonFile, filesize, type, function(err, metadata) {
-            if (err) return done(err);
+            if (err) {
+                assert.ifError(err, 'should not error');
+                return assert.end();
+            }
             assert.ok(err === null);
             assert.deepEqual(metadata, expectedMetadata_DC_polygon);
             assert.end();
@@ -415,7 +451,10 @@ var UPDATE = process.env.UPDATE;
         var filesize = 332;
         var type = '.geojson';
         datasourceProcessor.init(topoJsonFile, filesize, type, function(err, metadata) {
-            if (err) return done(err);
+            if (err) {
+                assert.ifError(err, 'should not error');
+                return assert.end();
+            }
             assert.ok(err === null);
             try {
                 assert.deepEqual(metadata, expectedMetadata_topo);
@@ -433,10 +472,13 @@ var UPDATE = process.env.UPDATE;
         var type = '.gpx';
         //Overwrites metadata json file if output does not match
         datasourceProcessor.init(gpxFile, filesize, type, function(err, metadata) {
-            if (err) return done(err);
+            if (err) {
+                assert.ifError(err, 'should not error');
+                return assert.end();
+            }
             if (UPDATE) fs.writeFileSync(path.resolve('test/fixtures/metadata_fells_loop.json'), JSON.stringify(metadata, null, 2));
             assert.deepEqual(metadata, expectedMetadata_fells_loop);
-            
+
             assert.end();
         });
     });
@@ -446,7 +488,10 @@ var UPDATE = process.env.UPDATE;
         var filesize = 36815;
         var type = '.gpx';
         datasourceProcessor.init(gpxFile, filesize, type, function(err, metadata) {
-            if (err) return done(err);
+            if (err) {
+                assert.ifError(err, 'should not error');
+                return assert.end();
+            }
             assert.ok(err === null);
             assert.deepEqual(metadata, expectedMetadata_fells_loop);
             assert.end();
@@ -499,26 +544,26 @@ var UPDATE = process.env.UPDATE;
             assert.end();
         });
     });
-    
+
     tape('Setting min/max zoom for Landsat 8 source: should not exceed z12', function(assert) {
-      
+
       var expectedMin = 7;
       var expectedMax = 13;
-      
+
       var proj = "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext  +no_defs";
-      
+
       var center = [-98.78906931331828, 49.15195306095049]; // 115-175-9
       var pixelSize = [30.000000000000000,-30.000000000000000];
-      
+
       datasourceProcessor.getMinMaxZoomGDAL(pixelSize, center, proj, function(err, minzoom, maxzoom) {
         assert.strictEqual(null, err);
         assert.equal(minzoom, expectedMin);
         assert.equal(maxzoom, expectedMax);
         assert.end();
       });
-      
+
     });
-    
+
     tape('Setting extent to zero: should return an error', function(assert) {
         var extent = [0, 0, 0, 0];
         var bytes = 1234;
@@ -569,7 +614,7 @@ var UPDATE = process.env.UPDATE;
     })(name, errorTests[name]);
     tape('should return an error due to invalid tif file', function(assert) {
         var file = path.resolve('test/data/errors/sampleError.tif');
-        var expectedMessage = 'Invalid gdal source. Error opening dataset';
+        var expectedMessage = 'Invalid GeoTIFF: could not open the file';
         datasourceProcessor.projectionFromRaster(file, function(err, projection) {
             assert.ok(err instanceof Error);
             assert.equal(expectedMessage, err.message);
@@ -582,7 +627,10 @@ var UPDATE = process.env.UPDATE;
         var type = '.shp';
         var expectedProj = '+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over';
         datasourceProcessor.getProjection(file, type, function(err, projection) {
-            if (err) return done(err);
+            if (err) {
+                assert.ifError(err, 'should not error');
+                return assert.end();
+            }
             assert.ok(err === null);
             assert.equal(expectedProj, projection);
             assert.end();
@@ -593,7 +641,10 @@ var UPDATE = process.env.UPDATE;
         var type = '.geojson';
         var expectedProj = '+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs';
         datasourceProcessor.getProjection(file, type, function(err, projection) {
-            if (err) return done(err);
+            if (err) {
+                assert.ifError(err, 'should not error');
+                return assert.end();
+            }
             assert.ok(err === null);
             assert.equal(expectedProj, projection);
             assert.end();
@@ -604,7 +655,10 @@ var UPDATE = process.env.UPDATE;
         var type = '.gpx';
         var expectedProj = '+init=epsg:4326';
         datasourceProcessor.getProjection(file, type, function(err, projection) {
-            if (err) return done(err);
+            if (err) {
+                assert.ifError(err, 'should not error');
+                return assert.end();
+            }
             assert.ok(err === null);
             assert.equal(expectedProj, projection);
             assert.end();
@@ -615,7 +669,10 @@ var UPDATE = process.env.UPDATE;
         var type = '.kml';
         var expectedProj = '+init=epsg:4326';
         datasourceProcessor.getProjection(file, type, function(err, projection) {
-            if (err) return done(err);
+            if (err) {
+                assert.ifError(err, 'should not error');
+                return assert.end();
+            }
             assert.ok(err === null);
             assert.equal(expectedProj, projection);
             assert.end();
@@ -642,5 +699,3 @@ var UPDATE = process.env.UPDATE;
         });
     });
 })();
-
-


### PR DESCRIPTION
Makes some changes to the flow when reading projection info from rasters. Compartmentalizes each set of node-gdal calls and provides clearer error messages in the event of a failure.

Fixes #64 

cc @willwhite @GretaCB 
