### PR TITLE
Deal with invalid geojson

### DIFF
--- a/lib/datasource-processor.js
+++ b/lib/datasource-processor.js
@@ -348,9 +348,9 @@ function processRasterDatasource(file, filesize, name, info, filetype, callback)
  */
 function getMinMaxZoomGDAL(pixelSize, center, proj, callback) {
     var circumference = 40075000;
-    
+
     pixelSize = convertToMeters(pixelSize, getUnitType(proj));
-    
+
     // Create lookup table to determine max zoom level for given spatial resolution
     var zoomLevels = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19];
     var spatialResolutions = zoomLevels.map(function(z) {
@@ -369,7 +369,7 @@ function getMinMaxZoomGDAL(pixelSize, center, proj, callback) {
 
 function convertToMeters(pixelSize, unit) {
   var circumference = 40075000;
-  
+
   var conversions = {
     'm': function(x) { return x; },
     'ft': function(x) { return x / 0.3048; },
@@ -379,7 +379,7 @@ function convertToMeters(pixelSize, unit) {
     'us-mi': function(x) { return x / 1609.34; },
     'decimal degrees': function(x) { return x / 360 * circumference; }
   }
-  
+
   var x = conversions[unit](pixelSize[0]);
   return [x, -1 * x];
 }
@@ -575,6 +575,10 @@ function getDatasourceProperties(file, filetype, callback) {
 
             var features = [];
             var featureset = ds.featureset();
+            if (!featureset) {
+                return callback(invalid('Source is not a valid FeatureCollection'));
+            }
+
             var feature = featureset.next();
             if (feature === undefined) {
                 return callback(invalid('Source appears to have no features data.'));
@@ -653,6 +657,9 @@ function getDatasource(options, layers, callback) {
             //Check to see that layer actually exists
             var features = [];
             var featureset = ds.featureset();
+            if (!featureset) {
+                return callback(invalid('Source is not a valid FeatureCollection'));
+            }
             var feature = featureset.next();
             if(feature === undefined) {
                 var index = layers.indexOf(layer);

--- a/package.json
+++ b/package.json
@@ -22,10 +22,11 @@
     "node": "0.10.x"
   },
   "devDependencies": {
-    "tape": "3.0.x",
     "coveralls": "~2.11.1",
     "istanbul": "~0.3.0",
-    "mapnik-test-data": "http://mapbox-npm.s3.amazonaws.com/package/mapnik-test-data-2.0.3-fece0a9c546074a1479e9eae2333184029bb2279.tgz"
+    "mapnik-test-data": "http://mapbox-npm.s3.amazonaws.com/package/mapnik-test-data-2.0.3-fece0a9c546074a1479e9eae2333184029bb2279.tgz",
+    "queue-async": "^1.0.7",
+    "tape": "3.0.x"
   },
   "scripts": {
     "test": "tape test/*.js",

--- a/test/fixtures/invalid-geojson/geometry.geojson
+++ b/test/fixtures/invalid-geojson/geometry.geojson
@@ -1,0 +1,4 @@
+{
+  "type": "Point",
+  "coordinates": [ 0, 0 ]
+}

--- a/test/fixtures/invalid-geojson/geometrycollection.geojson
+++ b/test/fixtures/invalid-geojson/geometrycollection.geojson
@@ -1,0 +1,9 @@
+{
+  "type": "GeometryCollection",
+  "geometries": [
+    {
+      "type": "Point",
+      "coordinates": [ 0, 0 ]
+    }
+  ]
+}

--- a/test/fixtures/invalid-geojson/notreally.geojson
+++ b/test/fixtures/invalid-geojson/notreally.geojson
@@ -1,0 +1,17 @@
+{
+  "type": "Bears",
+  "features": [
+    {
+      "type": "Black",
+      "properties": {
+        "size": "small"
+      }
+    },
+    {
+      "type": "Grizzly",
+      "properties": {
+        "size": "large"
+      }
+    }
+  ]
+}

--- a/test/fixtures/invalid-geojson/onefeature.geojson
+++ b/test/fixtures/invalid-geojson/onefeature.geojson
@@ -1,0 +1,10 @@
+{
+  "type": "Feature",
+  "properties": {
+    "name": "Null Island"
+  },
+  "geometry": {
+    "type": "Point",
+    "coordinates": [ 0, 0 ]
+  }
+}

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -2,7 +2,8 @@ var tape = require('tape'),
     path = require('path'),
     fs = require('fs'),
     testData = path.dirname(require.resolve('mapnik-test-data')),
-    mapnik_omnivore = require('../index.js');
+    mapnik_omnivore = require('../index.js'),
+    queue = require('queue-async');
 //json fixtures
 var expectedMetadata_world_merc = JSON.parse(fs.readFileSync(path.resolve('test/fixtures/metadata_world_merc.json')));
 var expectedMetadata_fells_loop = JSON.parse(fs.readFileSync(path.resolve('test/fixtures/metadata_fells_loop.json')));
@@ -113,5 +114,29 @@ var expectedMetadata_1week_earthquake = JSON.parse(fs.readFileSync(path.resolve(
             assert.equal('EINVALID', err.code);
             assert.equal(err.message, 'Error getting stats from file. File might not exist.');
             assert.end();
+        });
+    });
+
+    tape('should mark geojson invalid unless it is a FeatureCollection', function(assert) {
+        var invalidGeojsonFiles = path.resolve(__dirname, 'fixtures', 'invalid-geojson');
+        fs.readdir(invalidGeojsonFiles, function(err, files) {
+            if (err) throw err;
+
+            var q = queue();
+
+            files.forEach(function(filename) {
+                filename = path.join(invalidGeojsonFiles, filename);
+                q.defer(function(next) {
+                    mapnik_omnivore.getMetadata(filename, function(err, metadata) {
+                        assert.ok(err instanceof Error, 'expected error');
+                        assert.equal(err.code, 'EINVALID', 'expected error code');
+                        next();
+                    });
+                });
+            });
+
+            q.await(function() {
+                assert.end();
+            });
         });
     });


### PR DESCRIPTION
Adds test for error handling with invalid GeoJSON (or GeoJSON look-alike) files, adjusts functions to avoid calling `mapnik.Datasource().featureset().next()` if `mapnik.Datasource().featureset()` is null.

cc @GretaCB @springmeyer 