### PR TITLE
Handle unexpected mapnik parse errors

### DIFF
--- a/lib/datasource-processor.js
+++ b/lib/datasource-processor.js
@@ -568,21 +568,23 @@ function getDatasourceProperties(file, filetype, callback) {
         var ds;
         try { ds = new mapnik.Datasource(options); }
         catch(err) {
-            if (/Failed parse GeoJSON file/.test(err))
+            if (/Failed parse GeoJSON file/.test(err)) {
                 // If it couldn't be parsed, try again as topojson
                 return getDatasourceProperties(file, '.topojson', callback);
             }
+            return callback(invalid('Source file could not be parsed'));
+        }
 
-            var features = [];
-            var featureset = ds.featureset();
-            if (!featureset) {
-                return callback(invalid('Source appears to have no features data.'));
-            }
+        var features = [];
+        var featureset = ds.featureset();
+        if (!featureset) {
+            return callback(invalid('Source appears to have no features data.'));
+        }
 
-            var feature = featureset.next();
-            if (feature === undefined) {
-                return callback(invalid('Source appears to have no features data.'));
-            }
+        var feature = featureset.next();
+        if (feature === undefined) {
+            return callback(invalid('Source appears to have no features data.'));
+        }
 
         ds.dstype = 'geojson';
         return callback(null, [ 'OGRGeoJSON' ], ds);

--- a/test/fixtures/nested.properties.geojson
+++ b/test/fixtures/nested.properties.geojson
@@ -1,0 +1,17 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "properties": {
+        "panda": {
+          "bears": "know best"
+        }
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [ 0, 0 ]
+      }
+    }
+  ]
+}

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -140,3 +140,13 @@ var expectedMetadata_1week_earthquake = JSON.parse(fs.readFileSync(path.resolve(
             });
         });
     });
+
+    tape('should catch unexpected mapnik parsing errors', function(assert) {
+        var fixture = path.resolve(__dirname, 'fixtures', 'nested.properties.geojson');
+        mapnik_omnivore.getMetadata(fixture, function(err, metadata) {
+            assert.ok(err, 'expected error');
+            assert.equal(err.message, 'Source file could not be parsed');
+            assert.notOk(metadata, 'no metadata created');
+            assert.end();
+        });
+    });


### PR DESCRIPTION
It appears that there was some fumbled logic here that would allow a file that mapnik fails to parse to throw unhandled errors. In this case the mapnik error was

```
Error: <Attribute Value> expected but got: {"iconUrl":"\/im
```

`ogr2ogr` was able to deal with the file.

@springmeyer is going to work on isolating a test case, and I'd like to use that as a fixture here once you pin it down.