### PR TITLE
Upgrade to node-mapnik@3.1.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   ],
   "dependencies": {
     "srs": "~0.4.5",
-    "mapnik": "~3.1.2",
+    "mapnik": "https://github.com/mapnik/node-mapnik/tarball/master",
     "sphericalmercator": "~1.0.2",
     "gdal": "0.4.1"
   },

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   ],
   "dependencies": {
     "srs": "~0.4.5",
-    "mapnik": "https://github.com/mapnik/node-mapnik/tarball/master",
+    "mapnik": "~3.1.5",
     "sphericalmercator": "~1.0.2",
     "gdal": "0.4.1"
   },

--- a/test/fixtures/nested.properties.geojson
+++ b/test/fixtures/nested.properties.geojson
@@ -10,7 +10,7 @@
       },
       "geometry": {
         "type": "Point",
-        "coordinates": [ 0, 0 ]
+        "coordinates": [ -122, 48 ]
       }
     }
   ]

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -149,12 +149,10 @@ var expectedMetadata_1week_earthquake = JSON.parse(fs.readFileSync(path.resolve(
         });
     });
 
-    tape('should catch unexpected mapnik parsing errors', function(assert) {
+    tape.only('should catch unexpected mapnik parsing errors', function(assert) {
         var fixture = path.resolve(__dirname, 'fixtures', 'nested.properties.geojson');
         mapnik_omnivore.getMetadata(fixture, function(err, metadata) {
-            assert.ok(err, 'expected error');
-            assert.equal(err.message, 'Error calculating min/max zoom: Bounds invalid');
-            assert.notOk(metadata, 'no metadata created');
+            assert.ok(err === null);
             assert.end();
         });
     });


### PR DESCRIPTION
This change makes certain that Mapnik can now parse geojson that has nested properties.

It appears that a `[0 0]` point triggers `Error calculating min/max zoom: Bounds invalid` from mapnik-om which is a separate issue and was covering up the ability to have this test focus on the right issue.