### PR TITLE
Handle undefined maxzoom

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -5,9 +5,8 @@ var sm = new SphericalMercator();
 
 module.exports.zoomsBySize = function(filepath, extent, callback) {
   var maxSize = 500 * 1024;
-  var maxzoom = 22;
+  var max = 22;
   var min;
-  var max;
 
   fs.stat(filepath, function(err, stats) {
     if (err) return callback(err);
@@ -19,7 +18,7 @@ module.exports.zoomsBySize = function(filepath, extent, callback) {
     var tiles;
     var avg;
 
-    for (z = maxzoom; z >= 0; z--) {
+    for (z = max; z >= 0; z--) {
       bounds = sm.xyz(extent, z, false, 4326);
       x = (bounds.maxX - bounds.minX) + 1;
       y = (bounds.maxY - bounds.minY) + 1;

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "istanbul": "~0.3.0",
     "jscs": "^1.10.0",
     "jshint": "^2.6.0",
-    "mapnik-test-data": "https://mapbox-npm.s3.amazonaws.com/package/mapnik-test-data-2.0.4-c1c9aa8357c29a98a4be07efaa0bc790bebec74f.tgz",
+    "mapnik-test-data": "http://mapbox-npm.s3.amazonaws.com/package/mapnik-test-data-2.0.4-c1c9aa8357c29a98a4be07efaa0bc790bebec74f.tgz",
     "tape": "3.0.x"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "istanbul": "~0.3.0",
     "jscs": "^1.10.0",
     "jshint": "^2.6.0",
-    "mapnik-test-data": "http://mapbox-npm.s3.amazonaws.com/package/mapnik-test-data-2.0.3-fece0a9c546074a1479e9eae2333184029bb2279.tgz",
+    "mapnik-test-data": "https://mapbox-npm.s3.amazonaws.com/package/mapnik-test-data-2.0.4-c1c9aa8357c29a98a4be07efaa0bc790bebec74f.tgz",
     "tape": "3.0.x"
   },
   "scripts": {

--- a/test/fixtures/metadata_contours.json
+++ b/test/fixtures/metadata_contours.json
@@ -1,0 +1,36 @@
+{
+  "filename": "contours",
+  "filetype": ".shp",
+  "dstype": "shape",
+  "filesize": 24576628,
+  "center": [
+    -122.31742219942615,
+    37.87235316048361
+  ],
+  "extent": [
+    -122.31849442745843,
+    37.871487370753606,
+    -122.31634997139385,
+    37.87321895021363
+  ],
+  "minzoom": 19,
+  "maxzoom": 22,
+  "projection": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
+  "json": {
+    "vector_layers": [
+      {
+        "id": "contours",
+        "description": "",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "fields": {
+          "ID": "Number",
+          "elev": "Number"
+        }
+      }
+    ]
+  },
+  "layers": [
+    "contours"
+  ]
+}

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -12,6 +12,7 @@ var expectedMetadata_1week_earthquake = JSON.parse(fs.readFileSync(path.resolve(
 var expectedMetadata_sample_tif = JSON.parse(fs.readFileSync(path.resolve('test/fixtures/metadata_sample_tif.json')));
 var expectedMetadata_sample_vrt = JSON.parse(fs.readFileSync(path.resolve('test/fixtures/metadata_sample_vrt.json')));
 var expectedMetadata_topo = JSON.parse(fs.readFileSync(path.resolve('test/fixtures/metadata_topo.json')));
+var expectedMetadata_contours = JSON.parse(fs.readFileSync(path.resolve('test/fixtures/metadata_contours.json')));
 
 /**
  * Testing mapnik-omnivore.digest
@@ -26,6 +27,23 @@ tape('[SHAPE] Getting datasources: should return expected metadata', function(as
     assert.ok(err === null);
 
     assert.deepEqual(metadata, expectedMetadata_world_merc, 'expected metadata');
+    assert.end();
+  });
+});
+
+/**
+ * Testing mapnik-omnivore.digest
+ */
+tape('[SHAPE: super detailed] Getting datasources: should return expected metadata', function(assert) {
+  var file = testData + '/data/shp/contours/contours.shp';
+  mapnik_omnivore.digest(file, function(err, metadata) {
+    if (err) {
+      assert.ifError(err, 'should not error');
+      return assert.end();
+    }
+    assert.ok(err === null);
+
+    assert.deepEqual(metadata, expectedMetadata_contours, 'expected metadata');
     assert.end();
   });
 });

--- a/test/raster.test.js
+++ b/test/raster.test.js
@@ -188,7 +188,7 @@ tape('[VRT] Get extent', function(assert) {
 });
 
 tape('[VRT] Invalid georeference', function(assert) {
-  var fixture = path.join(__dirname, 'fixtures', 'invalid-georef-vrt', 'invalid.malformed.vrt');
+  var fixture = path.join(__dirname, 'fixtures', 'invalid.malformed.vrt');
   assert.throws(function() {
     new Raster(fixture);
   }, 'throws an error');


### PR DESCRIPTION
Make sure maxzoom is always defined. Defaults to 22 unless [average tilesize goes below 1000 bytes](https://github.com/mapbox/mapnik-omnivore/blob/master/lib/utils.js#L36).

cc @rclark 