### PR TITLE
cache_features: false for geojson in mapnik

### DIFF
--- a/lib/geojson.js
+++ b/lib/geojson.js
@@ -11,7 +11,8 @@ function GeoJSON(filepath) {
   this.filepath = filepath;
   this.datasource = new mapnik.Datasource({
     type: 'geojson',
-    file: filepath
+    file: filepath,
+    cache_features: false
   });
   this.extent = this.datasource.extent();
   this.center = [


### PR DESCRIPTION
This very significantly decreases the memory footprint required by mapnik for certain geojson files.