### PR TITLE
Loosen mapnik/gdal dep versions to avoid constant dupes

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
   ],
   "dependencies": {
     "srs": "~0.4.5",
-    "mapnik": "~3.2.0",
+    "mapnik": "^3.2.0",
     "sphericalmercator": "~1.0.2",
-    "gdal": "0.4.1",
+    "gdal": "^0.4.1",
     "mapbox-file-sniff": "0.3.0",
     "queue-async": "1.0.7"
   },


### PR DESCRIPTION
To avoid constant dep updates...loosen mapnik/gdal versions

cc @rclark 