### PR TITLE
Correctly fetch band info

### DIFF
--- a/lib/raster.js
+++ b/lib/raster.js
@@ -111,7 +111,7 @@ Raster.prototype.getBands = function() {
   var i;
   var band;
 
-  for (i = numBands; i <= numBands; i++) {
+  for (i = 1; i <= numBands; i++) {
     band = this.gdalDatasource.bands.get(i);
 
     try {

--- a/test/raster.test.js
+++ b/test/raster.test.js
@@ -363,3 +363,13 @@ tape('[VRT] Get zooms', function(assert) {
     assert.end();
   });
 });
+
+tape('[TIFF] Multi-band', function(assert) {
+  var file = testData + '/data/geotiff/DC_rgb.tif';
+  var source = new Raster(file);
+  var bands = source.getBands();
+
+  assert.equal(bands.length, 4);
+
+  assert.end();
+});


### PR DESCRIPTION
This was previously only picking up the last band present in a multi-band image.