### PR TITLE
Treat failure to fetch statistics as non-fatal

### DIFF
--- a/lib/raster.js
+++ b/lib/raster.js
@@ -116,7 +116,6 @@ Raster.prototype.getBands = function() {
 
     try {
       bandInfo = {
-        stats: band.getStatistics(false, true),
         scale: band.scale,
         unitType: band.unitType,
         rasterDatatype: band.dataType,
@@ -131,6 +130,13 @@ Raster.prototype.getBands = function() {
     }
     catch (err) {
       throw invalid('Invalid raster: could not read band information');
+    }
+
+    try {
+      bandInfo.stats = band.getStatistics(false, true);
+    }
+    catch (err) {
+      // ignore--this is non-fatal
     }
 
     bands.push(bandInfo);

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "istanbul": "~0.3.0",
     "jscs": "^1.10.0",
     "jshint": "^2.6.0",
-    "mapnik-test-data": "http://mapbox-npm.s3.amazonaws.com/package/mapnik-test-data-2.0.4-c1c9aa8357c29a98a4be07efaa0bc790bebec74f.tgz",
+    "mapnik-test-data": "https://mapbox-npm.s3.amazonaws.com/package/mapnik-test-data-2.0.5-c84800ed20a6a9bc2143dd11b1b2a3190b9ae698.tgz",
     "tape": "3.0.x"
   },
   "scripts": {

--- a/test/raster.test.js
+++ b/test/raster.test.js
@@ -373,3 +373,17 @@ tape('[TIFF] Multi-band', function(assert) {
 
   assert.end();
 });
+
+tape('[TIFF] JPEG-compressed', function(assert) {
+  var file = testData + '/data/geotiff/jpeg.tif';
+  var source = new Raster(file);
+
+  try {
+    source.getBands();
+  }
+  catch (err) {
+    assert.fail(err);
+  }
+
+  assert.end();
+});


### PR DESCRIPTION
Works around naturalatlas/node-gdal#103 (Statistics fail to load for JPEG-compressed GeoTIFFs) by treating exceptions thrown by `getStatistics` as non-fatal.

The tests depends on mapbox/mapnik-test-data#5 (a JPEG-compressed GeoTIFF) and naturalatlas/node-gdal#102 (enable JPEG support for GeoTIFFs).