### PR TITLE
Handle missing extent error

### DIFF
--- a/lib/ogr.js
+++ b/lib/ogr.js
@@ -49,11 +49,16 @@ Ogr.prototype.getExtent = function(callback) {
     if (err) return callback(err);
 
     var extent = new gdal.Envelope();
-    _this._layers.forEach(function(layer) {
-      extent.merge(layer.getExtent());
-    });
+    var result = _this._layers.reduce(function(result, layer) {
+      try {
+        extent.merge(layer.getExtent());
+      } catch (err) { return invalid('OGR source missing extent'); }
 
-    callback(null, [extent.minX, extent.minY, extent.maxX, extent.maxY]);
+      return true;
+    }, false);
+
+    if (result instanceof Error) return callback(result);
+    else callback(null, [extent.minX, extent.minY, extent.maxX, extent.maxY]);
   }
 };
 

--- a/test/fixtures/invalid.missingextent.kml
+++ b/test/fixtures/invalid.missingextent.kml
@@ -1,0 +1,26 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<kml xmlns='http://www.opengis.net/kml/2.2'>
+	<Document>
+		<name>Parkering</name>
+		<Placemark>
+			<name>Parkering</name>
+			<description><![CDATA[Adresse: Ærtekildevej 1<br>Postnummer: 4100<br>By: Ringsted<br>Tekst: Ubegrænset parkering]]></description>
+			<styleUrl>#icon-995</styleUrl>
+			<ExtendedData>
+				<Data name='Adresse'>
+					<value>Ærtekildevej 1</value>
+				</Data>
+				<Data name='Postnummer'>
+					<value>4100.0</value>
+				</Data>
+				<Data name='By'>
+					<value>Ringsted</value>
+				</Data>
+				<Data name='Tekst'>
+					<value>Ubegrænset parkering</value>
+				</Data>
+			</ExtendedData>
+			<address>Ærtekildevej 1, 4100, Ringsted</address>
+		</Placemark>
+	</Document>
+</kml>

--- a/test/ogr.test.js
+++ b/test/ogr.test.js
@@ -104,6 +104,17 @@ test('[KML] getExtent: kml file with layers', function(assert) {
   });
 });
 
+test('[KML] getExtent: should fail due to missing extent', function(assert) {
+  var fixture = path.join(__dirname, 'fixtures', 'invalid.missingextent.kml');
+  var ogr = new Ogr(fixture);
+
+  ogr.getExtent(function(err, extent) {
+    assert.ok(err, 'expected error');
+    assert.notOk(extent, 'no extent returned');
+    assert.end();
+  });
+});
+
 test('[GPX] getExtent: gpx file with layers', function(assert) {
   var fixture = path.join(testData, 'gpx', 'fells_loop.gpx');
   var ogr = new Ogr(fixture);


### PR DESCRIPTION
OGR sources without `layer.extent` will throw an [error here](https://github.com/mapbox/mapnik-omnivore/blob/master/lib/ogr.js#L53). Make sure to handle this error case.

```
var obj = getExtent.apply(this, arguments);
Error: Can't get layer extent without computing it
at Layer.gdal.Layer.getExtent (/mapnik-omnivore/node_modules/gdal/lib/gdal.js:71:22)
```