### PR TITLE
Set GDAL_DATA manually, when bundled libgdal directory is not available

### DIFF
--- a/lib/ogr.js
+++ b/lib/ogr.js
@@ -18,14 +18,21 @@ fieldDescriptions[gdal.OFTBinary] = 'a binary object';
 
 module.exports = Ogr;
 
-function Ogr(filepath) {
+//overrideGdalData only exists to make @flippmoke happy and have 100% coverage
+function Ogr(filepath, overrideGdalData) {
   this.filepath = filepath;
 
   //Mapbox Studio Classic packaging removes node-gdal's deps directory, which
   //includes files needed for GDAL_DATA.
   //If node-gdal's GDAL_DATA directory does not exists, assume enviroment
   //variable GDAL_DATA is correctly set, e.g. by node-srs
-  var gdal_data = gdal.config.get('GDAL_DATA');
+  var gdal_data;
+  if (overrideGdalData) {
+    gdal_data = overrideGdalData;
+  } else {
+    gdal_data = gdal.config.get('GDAL_DATA');
+  }
+
   if (!fs.existsSync(gdal_data)) {
     gdal_data = process.env.GDAL_DATA;
     if (fs.existsSync(gdal_data)) {
@@ -46,6 +53,11 @@ function Ogr(filepath) {
 Ogr.validFileType = ['kml', 'gpx'];
 Ogr.prototype.detailsName = 'json';
 Ogr.prototype.dstype = 'ogr';
+
+Ogr.prototype.gdalData = function(value) {
+  if (!arguments.length) return gdal.config.get('GDAL_DATA');
+  gdal.config.set('GDAL_DATA', value);
+};
 
 Ogr.prototype.getCenter = function(callback) {
   this.getExtent(function(err, extent) {

--- a/lib/ogr.js
+++ b/lib/ogr.js
@@ -1,3 +1,4 @@
+var fs = require('fs');
 var gdal = require('gdal');
 var invalid = require('./invalid');
 var srs = require('srs');
@@ -20,11 +21,25 @@ module.exports = Ogr;
 function Ogr(filepath) {
   this.filepath = filepath;
 
+  //Mapbox Studio Classic packaging removes node-gdal's deps directory, which
+  //includes files needed for GDAL_DATA.
+  //If node-gdal's GDAL_DATA directory does not exists, assume enviroment
+  //variable GDAL_DATA is correctly set, e.g. by node-srs
+  var gdal_data = gdal.config.get('GDAL_DATA');
+  if(!fs.existsSync(gdal_data)){
+    gdal_data = process.env.GDAL_DATA;
+    if(fs.existsSync(gdal_data)){
+      gdal.config.set('GDAL_DATA', gdal_data);
+    } else {
+      throw invalid('GDAL_DATA not found.');
+    }
+  }
+  
   try {
     this.gdalDatasource = gdal.open(filepath);
   }
   catch (err) {
-    throw invalid('Invalid OGR: could not open the file');
+    throw invalid('Invalid OGR: could not open the file.\n' + err);
   }
 }
 
@@ -52,7 +67,9 @@ Ogr.prototype.getExtent = function(callback) {
     var result = _this._layers.reduce(function(result, layer) {
       try {
         extent.merge(layer.getExtent());
-      } catch (err) { return invalid('OGR source missing extent'); }
+      } catch (err) {
+        return invalid('OGR source missing extent:\n' + err); 
+      }
 
       return true;
     }, false);

--- a/lib/ogr.js
+++ b/lib/ogr.js
@@ -26,15 +26,15 @@ function Ogr(filepath) {
   //If node-gdal's GDAL_DATA directory does not exists, assume enviroment
   //variable GDAL_DATA is correctly set, e.g. by node-srs
   var gdal_data = gdal.config.get('GDAL_DATA');
-  if(!fs.existsSync(gdal_data)){
+  if (!fs.existsSync(gdal_data)) {
     gdal_data = process.env.GDAL_DATA;
-    if(fs.existsSync(gdal_data)){
+    if (fs.existsSync(gdal_data)) {
       gdal.config.set('GDAL_DATA', gdal_data);
     } else {
       throw invalid('GDAL_DATA not found.');
     }
   }
-  
+
   try {
     this.gdalDatasource = gdal.open(filepath);
   }
@@ -68,7 +68,7 @@ Ogr.prototype.getExtent = function(callback) {
       try {
         extent.merge(layer.getExtent());
       } catch (err) {
-        return invalid('OGR source missing extent:\n' + err); 
+        return invalid('OGR source missing extent:\n' + err);
       }
 
       return true;

--- a/test/ogr.test.js
+++ b/test/ogr.test.js
@@ -12,6 +12,21 @@ function closeEnough(assert, found, expected, message) {
   assert.equal(found, expected, message);
 }
 
+test('[OGR] GDAL_DATA direcory not bundled with node-gdal', function(assert) {
+  // reason: 'gdal/deps' directory is removed when packaging Mapbox Studio Clasic to save space
+  var env_gdal_data = process.env.GDAL_DATA;
+  process.env.GDAL_DATA = 'gdal_data/thats/not/there';
+  var fixture = path.join(testData, 'kml', '1week_earthquake.kml');
+  assert.throws(function() {
+    new Ogr(fixture, 'gdal_data/thats/not/there');
+  }, 'throws if there is no GDAL_DATA directory');
+
+  process.env.GDAL_DATA = env_gdal_data;
+  var ogr = new Ogr(fixture, 'gdal_data/thats/not/there');
+  assert.equal(process.env.GDAL_DATA, ogr.gdalData(), 'gdal.config.get("GDAL_DATA") is equal to process.env.GDAL_DATA');
+  assert.end();
+});
+
 test('[OGR] Constructor error on malformed kml', function(assert) {
   var fixture = path.resolve(__dirname, 'fixtures', 'invalid.malformed.kml');
   assert.throws(function() {

--- a/test/ogr.test.js
+++ b/test/ogr.test.js
@@ -23,7 +23,9 @@ test('[OGR] GDAL_DATA direcory not bundled with node-gdal', function(assert) {
 
   process.env.GDAL_DATA = env_gdal_data;
   var ogr = new Ogr(fixture, 'gdal_data/thats/not/there');
-  assert.equal(process.env.GDAL_DATA, ogr.gdalData(), 'gdal.config.get("GDAL_DATA") is equal to process.env.GDAL_DATA');
+  assert.equal(ogr.gdalData(), process.env.GDAL_DATA, 'gdal.config.get("GDAL_DATA") is equal to process.env.GDAL_DATA');
+  ogr.gdalData('my/GDAL_DATA');
+  assert.equal(ogr.gdalData(), 'my/GDAL_DATA', 'GDAL_DATA is set and read correctly');
   assert.end();
 });
 


### PR DESCRIPTION
Fixes https://github.com/mapbox/mapbox-studio-classic/issues/1473

* Mapbox Studio Classic packaging removes "unnecessary" files, eg `node-gdal/deps`
* `node-gdal` is hardcoded to look for GDAL_DATA in `deps/libgdal/gdal/data`
* use `process.env.GDAL_DATA` that gets set by `node-srs` instead, if `gdal.config.get('GDAL_DATA')` does not point to a valid directory.

