### PR TITLE
Use latest node-srs

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "geodata"
   ],
   "dependencies": {
-    "srs": "~0.4.9",
+    "srs": "~1.0.0",
     "mapnik": "~3.4.1",
     "sphericalmercator": "~1.0.2",
     "gdal": "~0.7.0",


### PR DESCRIPTION
Upgrades to node-srs 1.x, which is now pure JS on top of node-gdal.