### PR TITLE
Update node-gdal to ~0.9.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "srs": "~1.1.0",
     "mapnik": "~3.5.0",
     "sphericalmercator": "~1.0.2",
-    "gdal": "~0.8.0",
+    "gdal": "~0.9.1",
     "mapbox-file-sniff": "~0.4.0",
     "queue-async": "~1.2.0"
   },


### PR DESCRIPTION
Pulls in latest node-gdal as part of `0.9.1` tagging party. cc/ @springmeyer for the review.