### PR TITLE
Scope extent in zoom calculations to avoid error

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -4,8 +4,8 @@ var SphericalMercator = require('sphericalmercator');
 var sm = new SphericalMercator();
 
 function normalizeLng(lng) {
-  if (lng <= 180 && lng >= -180) return lng;
-  return lng + Math.ceil(-1 * lng / 180) * 180;
+  if (lng >= 0) return Math.min(lng, 180);
+  return Math.max(lng, -180);
 }
 
 module.exports.zoomsBySize = function(filepath, extent, callback) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -3,10 +3,21 @@ var invalid = require('./invalid');
 var SphericalMercator = require('sphericalmercator');
 var sm = new SphericalMercator();
 
+function normalizeLng(lng) {
+  if (lng <= 180 && lng >= -180) return lng;
+  return lng + Math.ceil(-1 * lng / 180) * 180;
+}
+
 module.exports.zoomsBySize = function(filepath, extent, callback) {
   var maxSize = 500 * 1024;
   var max = 22;
   var min;
+  var normalizedExtent = [
+    normalizeLng(extent[0]),
+    extent[1],
+    normalizeLng(extent[2]),
+    extent[3]
+  ];
 
   fs.stat(filepath, function(err, stats) {
     if (err) return callback(err);
@@ -19,7 +30,7 @@ module.exports.zoomsBySize = function(filepath, extent, callback) {
     var avg;
 
     for (z = max; z >= 0; z--) {
-      bounds = sm.xyz(extent, z, false, 4326);
+      bounds = sm.xyz(normalizedExtent, z, false, 4326);
       x = (bounds.maxX - bounds.minX) + 1;
       y = (bounds.maxY - bounds.minY) + 1;
       tiles = x * y;

--- a/test/fixtures/way_east_point.geojson
+++ b/test/fixtures/way_east_point.geojson
@@ -1,0 +1,16 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          559.8125,
+          31.952162238024975
+        ]
+      }
+    }
+  ]
+}

--- a/test/fixtures/way_west_line.geojson
+++ b/test/fixtures/way_west_line.geojson
@@ -1,0 +1,22 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            -21.796875,
+            33.137551192346145
+          ],
+          [
+            -559.03124999999997,
+            31.952162238024975
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/test/geojson.test.js
+++ b/test/geojson.test.js
@@ -128,6 +128,30 @@ tape('[GeoJson] can open null island', function(assert) {
   });
 });
 
+tape('[GeoJson] can open point at lng just under 560', function(assert) {
+  var file = path.resolve('test/fixtures/way_east_point.geojson');
+  assert.ok(fs.existsSync(file));
+  var source = new GeoJSON(file);
+  source.getZooms(function(err, minzoom, maxzoom) {
+    assert.ifError(err, 'should not error');
+    assert.deepEqual(minzoom, 0);
+    assert.deepEqual(maxzoom, 6);
+    assert.end();
+  });
+});
+
+tape('[GeoJson] can open line stretching to lng just above -560', function(assert) {
+  var file = path.resolve('test/fixtures/way_west_line.geojson');
+  assert.ok(fs.existsSync(file));
+  var source = new GeoJSON(file);
+  source.getZooms(function(err, minzoom, maxzoom) {
+    assert.ifError(err, 'should not error');
+    assert.deepEqual(minzoom, 0);
+    assert.deepEqual(maxzoom, 6);
+    assert.end();
+  });
+});
+
 tape('[GeoJson] Get layers', function(assert) {
   var file = testData + '/data/geojson/DC_polygon.geo.json';
   var expectedLayers = ['DC_polygon.geo'];


### PR DESCRIPTION
I think this may be connected to https://github.com/mapbox/mapnik-omnivore/issues/142, and may illustrate an incomplete resolution to https://github.com/mapbox/mapnik-omnivore/issues/88.

As far as I can tell, this new fixture is valid GeoJSON, but when we try to get its min/max zoom, we end up hitting the error here: https://github.com/mapbox/mapnik-omnivore/blob/805d115acece01aa1977a0f4ba303bb7977bacf2/lib/utils.js#L27

