### PR TITLE
Update tests to work with mapnik >= v3.0.12

### DIFF
--- a/lib/geojson.js
+++ b/lib/geojson.js
@@ -69,7 +69,7 @@ GeoJSON.prototype.getDetails = function(callback) {
 GeoJSON.prototype.getLayers = function(callback) {
   // Validate layer
   var featureset = this.datasource.featureset();
-  if (!featureset) return callback(invalid('Invalid geojson: GeoJSON file must be a FeatureCollection'));
+  if (!featureset) return callback(invalid('Invalid geojson: does not contain any features'));
   if (featureset.next() === undefined) return callback(invalid('Invalid geojson: does not contain any features'));
   return callback(null, this.layers);
 };

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -93,7 +93,7 @@ tape('[GeoJson] digest function should return expected metadata', function(asser
 
 tape('[GeoJson] digest function should error and return sanitized message', function(assert) {
   var fixture = path.resolve(__dirname, 'fixtures', 'parse.error.json');
-  var expectedError = 'Invalid geojson: GeoJSON file must be a FeatureCollection';
+  var expectedError = 'Invalid geojson: does not contain any features';
   mapnik_omnivore.digest(fixture, function(err) {
     assert.ok(err, 'expected error');
     assert.deepEqual(err.message, expectedError, 'expected error message');


### PR DESCRIPTION
Starting from v3.0.12 Datasource always returns `valid` (not a NULL) Featureset object.