### PR TITLE
remove engine flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,9 +20,6 @@
     "type": "git",
     "url": "https://github.com/mapbox/mapnik-omnivore"
   },
-  "engines": {
-    "node": "0.10.x"
-  },
   "devDependencies": {
     "coveralls": "~2.11.1",
     "istanbul": "~0.3.0",


### PR DESCRIPTION
Removing the `engines` flag from the package.json. We are no longer testing on node v0.10.x - just v4 and v6.

cc @springmeyer @gretacb @who8mycakes