### PR TITLE
Clamp minzoom to z0 for vector data files under 10 MB

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -56,6 +56,7 @@ module.exports.zoomsBySize = function(filepath, extent, datasource, callback) {
         } else {
           min = z;
         }
+
         return callback(null, min, Math.max(max, smallestMaxZoom));
       } else if (tiles === 1 || z === 0) {
         min = 0;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -5,6 +5,7 @@ var sm = new SphericalMercator();
 
 var SMALLEST_MAX_ZOOM_FILE_SIZE = 1000000; // 1mb
 var DEFAULT_SMALLEST_MAX_ZOOM = 6;
+var SMALLEST_MIN_ZOOM_FILE_SIZE = 10000000; // 10mb
 
 module.exports.zoomsBySize = function(filepath, extent, datasource, callback) {
 
@@ -29,6 +30,9 @@ module.exports.zoomsBySize = function(filepath, extent, datasource, callback) {
     // set a "smallest max zoom" for different data types
     var smallestMaxZoom = stats.size < SMALLEST_MAX_ZOOM_FILE_SIZE ? dataTypeMaxZoom(datasource) : DEFAULT_SMALLEST_MAX_ZOOM;
 
+    // set z0 for files under 10 mb
+    var clamp_to_z0 = stats.size < SMALLEST_MIN_ZOOM_FILE_SIZE;
+
     for (z = max; z >= 0; z--) {
       bounds = sm.xyz(extent, z, false, 4326);
       x = (bounds.maxX - bounds.minX) + 1;
@@ -47,7 +51,11 @@ module.exports.zoomsBySize = function(filepath, extent, datasource, callback) {
 
       if (avg < 1000) max = z;
       if (avg > maxSize) {
-        min = z;
+        if (clamp_to_z0) {
+          min = 0;
+        } else {
+          min = z;
+        }
         return callback(null, min, Math.max(max, smallestMaxZoom));
       } else if (tiles === 1 || z === 0) {
         min = 0;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -5,7 +5,7 @@ var sm = new SphericalMercator();
 
 var SMALLEST_MAX_ZOOM_FILE_SIZE = 1000000; // 1mb
 var DEFAULT_SMALLEST_MAX_ZOOM = 6;
-var SMALLEST_MIN_ZOOM_FILE_SIZE = 10000000; // 10mb
+var SMALLEST_MIN_ZOOM_FILE_SIZE = process.env.SMALLEST_MIN_ZOOM_FILE_SIZE ? +process.env.SMALLEST_MIN_ZOOM_FILE_SIZE : 10000000; // 10mb
 
 module.exports.zoomsBySize = function(filepath, extent, datasource, callback) {
 

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,5 +1,40 @@
 var tape = require('tape');
 var utils = require('../lib/utils.js');
+var os = require('os');
+var path = require('path');
+var fs = require('fs');
+var tmp_dir = os.tmpdir();
+
+tape('[zoomsBySize] we detect z0 for file less than 10 MB', function(assert) {
+  var filepath = path.join(tmp_dir,'test.csv');
+  fd = fs.openSync(filepath, 'w+')
+  fs.writeSync(fd,'x,y');
+  for (var i=0;i<1000000;++i) {
+    fs.writeSync(fd,'-122,48');
+  }
+  assert.ok(fs.statSync(filepath).size < 10000000);
+  utils.zoomsBySize(filepath,[ -122,48,-122,48],function(err,min,max) {
+      assert.equal(min,0);
+      assert.equal(max,22);
+      assert.end();
+  });
+});
+
+tape('[zoomsBySize] we detect > z0 for file greater than 10 MB', function(assert) {
+  var filepath = path.join(tmp_dir,'test2.csv');
+  fd = fs.openSync(filepath, 'w+')
+  fs.writeSync(fd,'x,y');
+  for (var i=0;i<2000000;++i) {
+    fs.writeSync(fd,'-122,48');
+  }
+  assert.ok(fs.statSync(filepath).size > 10000000);
+  utils.zoomsBySize(filepath,[ -122,48,-122,48],function(err,min,max) {
+      assert.equal(min,22);
+      assert.equal(max,22);
+      assert.end();
+  });
+});
+
 
 tape('[CONVERT TO METERS] Should not convert cell sizes in m', function(assert) {
   var cellSize = [10, 10];

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -6,35 +6,36 @@ var fs = require('fs');
 var tmp_dir = os.tmpdir();
 
 tape('[zoomsBySize] we detect z0 for file less than 10 MB', function(assert) {
-  var filepath = path.join(tmp_dir,'test.csv');
-  fd = fs.openSync(filepath, 'w+')
-  fs.writeSync(fd,'x,y');
-  for (var i=0;i<1000000;++i) {
-    fs.writeSync(fd,'-122,48');
+  var filepath = path.join(tmp_dir, 'test.csv');
+  var fd = fs.openSync(filepath, 'w+');
+  fs.writeSync(fd, 'x,y');
+  for (var i = 0; i < 1000000; ++i) {
+    fs.writeSync(fd, '-122,48');
   }
+
   assert.ok(fs.statSync(filepath).size < 10000000);
-  utils.zoomsBySize(filepath,[ -122,48,-122,48],function(err,min,max) {
-      assert.equal(min,0);
-      assert.equal(max,22);
-      assert.end();
+  utils.zoomsBySize(filepath, [-122, 48, -122, 48], function(err, min, max) {
+    assert.equal(min, 0);
+    assert.equal(max, 22);
+    assert.end();
   });
 });
 
 tape('[zoomsBySize] we detect > z0 for file greater than 10 MB', function(assert) {
-  var filepath = path.join(tmp_dir,'test2.csv');
-  fd = fs.openSync(filepath, 'w+')
-  fs.writeSync(fd,'x,y');
-  for (var i=0;i<2000000;++i) {
-    fs.writeSync(fd,'-122,48');
+  var filepath = path.join(tmp_dir, 'test2.csv');
+  var fd = fs.openSync(filepath, 'w+');
+  fs.writeSync(fd, 'x,y');
+  for (var i = 0; i < 2000000; ++i) {
+    fs.writeSync(fd, '-122,48');
   }
+
   assert.ok(fs.statSync(filepath).size > 10000000);
-  utils.zoomsBySize(filepath,[ -122,48,-122,48],function(err,min,max) {
-      assert.equal(min,22);
-      assert.equal(max,22);
-      assert.end();
+  utils.zoomsBySize(filepath, [-122, 48, -122, 48], function(err, min, max) {
+    assert.equal(min, 22);
+    assert.equal(max, 22);
+    assert.end();
   });
 });
-
 
 tape('[CONVERT TO METERS] Should not convert cell sizes in m', function(assert) {
   var cellSize = [10, 10];


### PR DESCRIPTION
Change mapnik-om to always decide to display the min zoom as z0 for small files (under 10 MB).